### PR TITLE
Some quotient group cleanup

### DIFF
--- a/src/for_mathlib/quotient_group.lean
+++ b/src/for_mathlib/quotient_group.lean
@@ -4,8 +4,6 @@ universes u v
 
 variables {G : Type u} [group G] (N : set G) [normal_subgroup N] {H : Type v} [group H]
 
-namespace group 
-
 local attribute [instance] left_rel normal_subgroup.to_is_subgroup
 
 definition quotient_group := left_cosets N 
@@ -14,56 +12,49 @@ local notation ` Q ` := quotient_group N
 
 instance : group Q := left_cosets.group N 
 
-instance quotient.inhabited : inhabited Q := ⟨1⟩
 
-definition quotient.mk : G → Q := λ g, ⟦g⟧
+namespace group.quotient
 
-instance is_group_hom_quotient_mk : is_group_hom (quotient.mk N) := by refine {..}; intros; refl 
+instance inhabited : inhabited Q := ⟨1⟩
 
-def quotient.lift (φ : G → H) [Hφ : is_group_hom φ] (HN : ∀x∈N, φ x = 1) (q : Q) : H :=
+def mk : G → Q := λ g, ⟦g⟧
+
+instance is_group_hom_quotient_mk : is_group_hom (mk N) := by refine {..}; intros; refl 
+
+def lift (φ : G → H) [Hφ : is_group_hom φ] (HN : ∀x∈N, φ x = 1) (q : Q) : H :=
 q.lift_on φ $ assume a b (hab : a⁻¹ * b ∈ N),
-(calc φ a = φ a * 1 : by rw mul_one
+(calc φ a = φ a * 1           : by simp
 ...       = φ a * φ (a⁻¹ * b) : by rw HN (a⁻¹ * b) hab
 ...       = φ (a * (a⁻¹ * b)) : by rw is_group_hom.mul φ a (a⁻¹ * b)
-...       = φ ((a * a⁻¹) * b) : by rw mul_assoc;refl
-...       = φ (1 * b)         : by rw mul_inv_self
-...       = φ b               : by rw one_mul)
+...       = φ b               : by simp)
 
-@[simp] lemma quotient.lift_mk {φ : G → H} [Hφ : is_group_hom φ] (HN : ∀x∈N, φ x = 1) (g : G) :
-  quotient.lift N φ HN ⟦g⟧ = φ g := by refl
+@[simp] lemma lift_mk {φ : G → H} [Hφ : is_group_hom φ] (HN : ∀x∈N, φ x = 1) (g : G) :
+  lift N φ HN ⟦g⟧ = φ g := rfl
 
-@[simp] lemma quotient.lift_mk' {φ : G → H} [Hφ : is_group_hom φ] (HN : ∀x∈N, φ x = 1) (g : G) :
-  quotient.lift N φ HN (group.quotient.mk N g) = φ g := by refl
+@[simp] lemma lift_mk' {φ : G → H} [Hφ : is_group_hom φ] (HN : ∀x∈N, φ x = 1) (g : G) :
+  lift N φ HN (mk N g) = φ g := rfl
 
-
-instance is_group_hom_quotient_lift (φ : G → H) [Hφ : is_group_hom φ] (HN : ∀x∈N, φ x = 1) :
-  is_group_hom (group.quotient.lift N φ HN) := 
+variables (φ : G → H) [Hφ : is_group_hom φ] (HN : ∀x∈N, φ x = 1)
+include Hφ
+instance is_group_hom_quotient_lift  :
+  is_group_hom (lift N φ HN) := 
 ⟨λ q r, quotient.induction_on₂ q r $ λ a b, show φ (a * b) = φ a * φ b, from is_group_hom.mul φ a b⟩
 
---lemma is_group_hom_quotient_lift (φ : G → H) {HN : ∀x y, x⁻¹ * y ∈ N → φ x = φ y}
---[Hφ : is_group_hom φ] : is_group_hom (λ q : Q, quotient.lift_on q φ HN) := 
---⟨λ q r, quotient.induction_on₂ q r $ λ a b, show φ (a * b) = φ a * φ b, from is_group_hom.mul φ a b⟩
+open function is_group_hom
 
-open function 
-
-lemma quotient.injective_lift (φ : G → H) [Hφ : is_group_hom φ]
-  (HN : N = {x | φ x = 1}) : injective 
---  (quotient.lift N φ $ λ x h,by rwa HN at h) 
-  (group.quotient.lift N φ $ λ x h, by rwa HN at h)
-  :=
+lemma injective_ker_lift : injective (lift (ker φ) φ $ λ x h, (mem_ker φ).1 h) :=
 assume a b, quotient.induction_on₂ a b $ assume a b (h : φ a = φ b), quotient.sound $ 
-have φ (a⁻¹ * b) = 1, by rw [Hφ.mul,←h,is_group_hom.inv φ,inv_mul_self],
-show a⁻¹ * b ∈ N,from HN.symm ▸ this
+show a⁻¹ * b ∈ ker φ, by rw [mem_ker φ, Hφ.mul,←h,is_group_hom.inv φ,inv_mul_self]
 
+end group.quotient
+
+namespace group
 variables {cG : Type u} [comm_group cG] (cN : set cG) [normal_subgroup cN] 
 
-instance : comm_group (group.quotient_group cN) := 
+instance : comm_group (quotient_group cN) := 
 { mul_comm := λ a b,quotient.induction_on₂ a b $ λ g h, 
     show ⟦g * h⟧ = ⟦h * g⟧, 
     by rw [mul_comm g h],
   ..left_cosets.group cN
 }
-
 end group
-
-

--- a/src/valuation_spectrum.lean
+++ b/src/valuation_spectrum.lean
@@ -38,9 +38,8 @@ begin
   letI Hφ : is_group_hom φ :=
   { mul := λ a b,finsupp.prod_add_index H0 Hprod,
   },
-  let N := is_group_hom.ker φ,
-  let Γ1 := group.quotient_group N,
-  exact Γ1 
+  
+  exact quotient_group (is_group_hom.ker φ)
 end 
 
 instance valuation.minimal_value_group_is_linear_ordered_comm_group
@@ -59,9 +58,9 @@ begin
   { mul := λ a b,finsupp.prod_add_index H0 Hprod,
   },
   let N := is_group_hom.ker φ,
-  let Γ1 := group.quotient_group N,
-  let ψ : Γ1 → Γ2 := group.quotient.lift N φ (λ _,(is_group_hom.mem_ker φ).1),
-  have Hψ : function.injective ψ := group.quotient.injective_lift N φ
+  let Γ1 := quotient_group N,
+  let ψ : Γ1 → Γ2 := quotient_group.lift N φ (λ _,(is_group_hom.mem_ker φ).1),
+  have Hψ : function.injective ψ := quotient_group.injective_ker_lift φ
     begin
     funext,apply propext,
     show x ∈ N ↔ _,

--- a/src/valuation_spectrum_all_functions_in_one.lean
+++ b/src/valuation_spectrum_all_functions_in_one.lean
@@ -34,14 +34,9 @@ begin
   { mul := λ a b,finsupp.prod_add_index H0 Hprod,
   },
   let N := is_group_hom.ker φ,
-  let Γ1 := group.quotient_group N,
+  let Γ1 := quotient_group N,
   let ψ : Γ1 → Γ2 := group.quotient.lift N φ (λ _,(is_group_hom.mem_ker φ).1),
-  have Hψ : function.injective ψ := group.quotient.injective_lift N φ
-    begin
-    funext,apply propext,
-    show x ∈ N ↔ _,
-    exact is_group_hom.mem_ker φ,
-    end,
+  have Hψ : function.injective ψ := group.quotient.injective_ker_lift φ,
   letI Γ1linord : linear_order Γ1 := 
   { le := λ g h,ψ g ≤ ψ h,
     le_refl := λ _,le_refl _,


### PR DESCRIPTION
Minor tweaks while I was reading your quotient group stuff. The only significant one is in `quotient.injective_lift` where you had that strange hypothesis `(HN : N = {x | φ x = 1})` about subgroup `N` instead of clearly saying this is a lemma about G/ker φ. Maybe this was preparation  for the case where N contains ker φ? Anyway, stating it like I did saves a couple of lines in the valuation files.