### PR TITLE
Forgotten valuation_spectrum fix

### DIFF
--- a/src/valuation_spectrum.lean
+++ b/src/valuation_spectrum.lean
@@ -32,12 +32,10 @@ begin
   let FG : Type u1 := multiplicative (R →₀ ℤ), -- free group on R
   let φ₀ : R → Γ2 := λ r, option.get_or_else (f2 r) 1, 
   let φ : FG → Γ2 := λ f, finsupp.prod f (λ r n,(φ₀ r) ^ n),
-  have H0 : ∀ (a : R), φ₀ a ^ 0 = 1 := λ a,rfl,
+  have H0 : ∀ (a : R), φ₀ a ^ 0 = 1 := λ a, rfl,
   have Hprod:  ∀ (a : R) (b₁ b₂ : ℤ), φ₀ a ^ (b₁ + b₂) = φ₀ a ^ b₁ * φ₀ a ^ b₂ := 
     λ a b₁ b₂, gpow_add _ _ _,
-  letI Hφ : is_group_hom φ :=
-  { mul := λ a b,finsupp.prod_add_index H0 Hprod,
-  },
+  letI Hφ : is_group_hom φ := ⟨λ a b,finsupp.prod_add_index H0 Hprod⟩,
   
   exact quotient_group (is_group_hom.ker φ)
 end 
@@ -59,13 +57,8 @@ begin
   },
   let N := is_group_hom.ker φ,
   let Γ1 := quotient_group N,
-  let ψ : Γ1 → Γ2 := quotient_group.lift N φ (λ _,(is_group_hom.mem_ker φ).1),
-  have Hψ : function.injective ψ := quotient_group.injective_ker_lift φ
-    begin
-    funext,apply propext,
-    show x ∈ N ↔ _,
-    exact is_group_hom.mem_ker φ,
-    end,
+  let ψ : Γ1 → Γ2 := group.quotient.lift N φ (λ _,(is_group_hom.mem_ker φ).1),
+  have Hψ : function.injective ψ := group.quotient.injective_ker_lift φ,
   letI Γ1linord : linear_order Γ1 := 
   { le := λ g h,ψ g ≤ ψ h,
     le_refl := λ _,le_refl _,
@@ -101,14 +94,9 @@ begin
   { mul := λ a b,finsupp.prod_add_index H0 Hprod,
   },
   let N := is_group_hom.ker φ,
-  let Γ1 := group.quotient_group N,
+  let Γ1 := quotient_group N,
   let ψ : Γ1 → Γ2 := group.quotient.lift N φ (λ _,(is_group_hom.mem_ker φ).1),
-  have Hψ : function.injective ψ := group.quotient.injective_lift N φ
-    begin
-    funext,apply propext,
-    show x ∈ N ↔ _,
-    exact is_group_hom.mem_ker φ,
-    end,
+  have Hψ : function.injective ψ := group.quotient.injective_ker_lift φ,
   letI Γ1linord : linear_order Γ1 := 
   { le := λ g h,ψ g ≤ ψ h,
     le_refl := λ _,le_refl _,
@@ -147,14 +135,9 @@ begin
   { mul := λ a b,finsupp.prod_add_index H0 Hprod,
   },
   let N := is_group_hom.ker φ,
-  let Γ1 := group.quotient_group N,
+  let Γ1 := quotient_group N,
   let ψ : Γ1 → Γ2 := group.quotient.lift N φ (λ _,(is_group_hom.mem_ker φ).1),
-  have Hψ : function.injective ψ := group.quotient.injective_lift N φ
-    begin
-    funext,apply propext,
-    show x ∈ N ↔ _,
-    exact is_group_hom.mem_ker φ,
-    end,
+  have Hψ : function.injective ψ := group.quotient.injective_ker_lift φ,
   letI Γ1linord : linear_order Γ1 := 
   { le := λ g h,ψ g ≤ ψ h,
     le_refl := λ _,le_refl _,
@@ -221,14 +204,9 @@ begin
   { mul := λ a b,finsupp.prod_add_index H0 Hprod,
   },
   let N := is_group_hom.ker φ,
-  let Γ1 := group.quotient_group N,
+  let Γ1 := quotient_group N,
   let ψ : Γ1 → Γ2 := group.quotient.lift N φ (λ _,(is_group_hom.mem_ker φ).1),
-  have Hψ : function.injective ψ := group.quotient.injective_lift N φ
-    begin
-    funext,apply propext,
-    show x ∈ N ↔ _,
-    exact is_group_hom.mem_ker φ,
-    end,
+  have Hψ : function.injective ψ := group.quotient.injective_ker_lift φ,
   letI Γ1linord : linear_order Γ1 := 
   { le := λ g h,ψ g ≤ ψ h,
     le_refl := λ _,le_refl _,


### PR DESCRIPTION
Sorry, I messed up PR #6, I forgot to include my moditications on `valuation_spectrum.lean`, which brought an inconsistent state. I blame VScode which always hides the fact that files are not saved. After two cosmetic changes in the beginning, the only changes are related to my `group.quotient.injective_ker_lift` replacing your version.