### PR TITLE
Get rid of nat.Prime

### DIFF
--- a/src/perfectoid_space.lean
+++ b/src/perfectoid_space.lean
@@ -1,4 +1,10 @@
--- definitions of adic_space, preadic_space, Huber_pair etc
+/-
+Perfectoid Spaces
+
+by Kevin Buzzard, Johan Commelin, and Patrick Massot
+-/
+
+-- We import definitions of adic_space, preadic_space, Huber_pair etc
 import adic_space
 import Tate_ring
 import power_bounded
@@ -6,11 +12,10 @@ import power_bounded
 -- notation for the power bounded subring
 local postfix `ᵒ` : 66 := power_bounded_subring
 
-open nat.Prime power_bounded_subring topological_space
-variable [nat.Prime] -- fix a prime p
+open power_bounded_subring topological_space
 
 /-- A perfectoid ring, following Fontaine Sem. Bourbaki-/
-structure perfectoid_ring (R : Type) [Huber_ring R] extends Tate_ring R : Prop :=
+structure perfectoid_ring (R : Type) [Huber_ring R] (p : ℕ) [is_prime p] extends Tate_ring R : Prop :=
 (complete : is_complete_hausdorff R)
 (uniform  : is_uniform R)
 (ramified : ∃ ϖ : pseudo_uniformizer R, (ϖ^p : Rᵒ) ∣ p)
@@ -23,9 +28,9 @@ structure perfectoid_ring (R : Type) [Huber_ring R] extends Tate_ring R : Prop :
 
 /-- Condition for an object of CLVRS to be perfectoid: every point should have an open
 neighbourhood isomorphic to Spa(A) for some perfectoid ring A.-/
-def CLVRS.is_perfectoid (X : CLVRS) : Prop :=
-∀ x : X, ∃ (U : opens X) (A : Huber_pair) [perfectoid_ring A],
+def CLVRS.is_perfectoid (X : CLVRS) (p : ℕ) [is_prime p]: Prop :=
+∀ x : X, ∃ (U : opens X) (A : Huber_pair) [perfectoid_ring A p],
   (x ∈ U) ∧ (Spa A ≊ U)
 
 /-- The category of perfectoid spaces.-/
-def PerfectoidSpace := {X : CLVRS // X.is_perfectoid}
+def PerfectoidSpace (p : ℕ) [is_prime p] := {X : CLVRS // X.is_perfectoid p}


### PR DESCRIPTION
There are other possibilities (not using type class at all, changing order of arguments etc.)